### PR TITLE
fix: add domain only import functionality (#261)

### DIFF
--- a/app/controllers/admin/export_domain_blocks_controller.rb
+++ b/app/controllers/admin/export_domain_blocks_controller.rb
@@ -30,11 +30,12 @@ module Admin
           next if DomainBlock.rule_for(domain).present?
 
           domain_block = DomainBlock.new(domain: domain,
-                                         severity: row['#severity'].strip,
-                                         reject_media: row['#reject_media'].strip,
-                                         reject_reports: row['#reject_reports'].strip,
-                                         public_comment: row['#public_comment'].strip,
-                                         obfuscate: row['#obfuscate'].strip)
+                                         severity: default_block_param(row, '#severity', 'suspend'),
+                                         reject_media: default_block_param(row, '#reject_media', false),
+                                         reject_reports: default_block_param(row, '#reject_reports', false),
+                                         public_comment: default_block_param(row, '#public_comment', nil),
+                                         obfuscate: default_block_param(row, '#obfuscate', false))
+
           if domain_block.save
             DomainBlockWorker.perform_async(domain_block.id)
             log_action :create, domain_block
@@ -63,6 +64,12 @@ module Admin
           content << [instance.domain, instance.severity, instance.reject_media, instance.reject_reports, instance.public_comment, instance.obfuscate]
         end
       end
+    end
+
+    def default_block_param(row, key, default)
+      return default if row[key].nil?
+
+      row[key].strip
     end
   end
 end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -70,7 +70,7 @@ en:
       form_challenge:
         current_password: You are entering a secure area
       imports:
-        data: CSV file exported from another Ecko or Mastodon server
+        data: CSV file exported from another Ecko or Mastodon server, Please make sure that any existing domains will be merged with the new configuration. You can also add csv with only domains which will take in default values
       invite_request:
         text: This will help us review your application
       ip_block:

--- a/spec/controllers/admin/export_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_blocks_controller_spec.rb
@@ -37,6 +37,22 @@ RSpec.describe Admin::ExportDomainBlocksController, type: :controller do
       expect(response).to have_http_status(200)
       expect(response.body).to eq(IO.read(File.join(file_fixture_path, 'domain_blocks.csv')))
     end
+
+    it 'blocks imported domains with only domains csv' do
+      allow(DomainBlockWorker).to receive(:perform_async).and_return(true)
+
+      post :import, params: { admin_import: { data: fixture_file_upload('domain_only_blocks.csv') } }
+
+      expect(response).to redirect_to(admin_instances_path(limited: '1'))
+      expect(DomainBlockWorker).to have_received(:perform_async).exactly(2).times
+
+      # Header should not be imported
+      expect(DomainBlock.where(domain: '#domain').present?).to eq(false)
+
+      # Domains should now be added
+      get :export, params: { format: :csv }
+      expect(response).to have_http_status(200)
+    end
   end
 
   it 'displays error on no file selected' do

--- a/spec/fixtures/files/domain_only_blocks.csv
+++ b/spec/fixtures/files/domain_only_blocks.csv
@@ -1,0 +1,2 @@
+bad.domain
+worse.domain


### PR DESCRIPTION
Issue: #261 
This pr deals with adding a functionality to make sure csvs with just domains are allowed to be imported with certain default values. Further details are commented in the issue itself.