### PR TITLE
Tune simple domain blocklist defaults, tweak wording in UI

### DIFF
--- a/app/controllers/admin/export_domain_blocks_controller.rb
+++ b/app/controllers/admin/export_domain_blocks_controller.rb
@@ -30,11 +30,11 @@ module Admin
           next if DomainBlock.rule_for(domain).present?
 
           domain_block = DomainBlock.new(domain: domain,
-                                         severity: default_block_param(row, '#severity', 'suspend'),
+                                         severity: default_block_param(row, '#severity', 'silence'),
                                          reject_media: default_block_param(row, '#reject_media', false),
                                          reject_reports: default_block_param(row, '#reject_reports', false),
                                          public_comment: default_block_param(row, '#public_comment', nil),
-                                         obfuscate: default_block_param(row, '#obfuscate', false))
+                                         obfuscate: default_block_param(row, '#obfuscate', true))
 
           if domain_block.save
             DomainBlockWorker.perform_async(domain_block.id)

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -70,7 +70,7 @@ en:
       form_challenge:
         current_password: You are entering a secure area
       imports:
-        data: CSV file exported from another Ecko or Mastodon server, Please make sure that any existing domains will be merged with the new configuration. You can also add csv with only domains which will take in default values
+        data: CSV file exported from another Ecko or Mastodon server. Please be aware that this will merge new domains with existing ones. You can also upload a list of domains one-per-line which will be given the following defaults: severity of Silence, blank public comment, and obfuscated domain names (if shown).
       invite_request:
         text: This will help us review your application
       ip_block:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -70,7 +70,7 @@ en:
       form_challenge:
         current_password: You are entering a secure area
       imports:
-        data: CSV file exported from another Ecko or Mastodon server. Please be aware that this will merge new domains with existing ones. You can also upload a list of domains one-per-line which will be given the following defaults: severity of Silence, blank public comment, and obfuscated domain names (if shown).
+        data: CSV file exported from another Ecko or Mastodon server. Please be aware that this will merge new domains with existing ones. You can also upload a list of domains one-per-line (will be given default values of severity of Silence, a blank public comment, and obfuscated domain names).
       invite_request:
         text: This will help us review your application
       ip_block:


### PR DESCRIPTION
Minor change to domain blocklist defaults to reduce unintended consequences of content removal. This only affects upload of a simplified blocklist.

Also clarifies the text in the UI for blocklist import.

Related to #261 