### PR TITLE
feature: add new tootctl command to import urls from a csv url download

### DIFF
--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -157,15 +157,15 @@ module Mastodon
       end
     end
 
-    option :url, type: :string, default: 'https://csv.rathersafe.space/f.php?d=1&h=39IM2DCd', aliases: [:u]
-    desc 'crawl [START]', 'Crawl all known peers, optionally beginning at START'
+    option :url, type: :string, default: '', aliases: [:u]
+    desc 'import [URL]', 'Import blocked domains based on the csv url provided'
     long_desc <<-LONG_DESC
       Imports all the block list in the form of csv response
       There are two ways to import a csv, the exported pattern of the csv
       and the domain only way of pattern
     LONG_DESC
-    def import_blocked
-      domains_csv = HTTP.get(options[:url]).body.readpartial
+    def import_blocked(url)
+      domains_csv = HTTP.get(url).body.readpartial
       default_headers = %w(#domain #severity #reject_media #reject_reports #public_comment #obfuscate)
 
       domains = CSV.parse(domains_csv, headers: default_headers)

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -157,6 +157,48 @@ module Mastodon
       end
     end
 
+    option :url, type: :string, default: 'https://csv.rathersafe.space/f.php?d=1&h=39IM2DCd', aliases: [:u]
+    desc 'crawl [START]', 'Crawl all known peers, optionally beginning at START'
+    long_desc <<-LONG_DESC
+      Imports all the block list in the form of csv response
+      There are two ways to import a csv, the exported pattern of the csv
+      and the domain only way of pattern
+    LONG_DESC
+    def import_blocked
+      domains_csv = HTTP.get(options[:url]).body.readpartial
+      default_headers = %w(#domain #severity #reject_media #reject_reports #public_comment #obfuscate)
+
+      domains = CSV.parse(domains_csv, headers: default_headers)
+      created = 0
+      merged = 0
+
+      domains.each do |row|
+        domain = row['#domain'].strip
+
+        if DomainBlock.rule_for(domain).present?
+          say("#{domain} is already present in the block list or is ruled out", :red)
+          next
+        end
+
+        domain_block = DomainBlock.new(
+          domain: domain,
+          severity: default_block_param(row, '#severity', 'silence'),
+          reject_media: default_block_param(row, '#reject_media', false),
+          reject_reports: default_block_param(row, '#reject_reports', false),
+          public_comment: default_block_param(row, '#public_comment', nil),
+          obfuscate: default_block_param(row, '#obfuscate', true)
+        )
+
+        created += 1
+        DomainBlockWorker.perform_async(domain_block.id) if domain_block.save
+        say("Domain block with domain: #{domain} has been created", :green)
+      end
+
+      say("#{created - merged} new domains created", :green)
+      say("#{domains.length - created} domains ruled out", :red)
+    end
+
+
     private
 
     def stats_to_summary(stats, processed, failed, start_at)
@@ -181,6 +223,12 @@ module Mastodon
     def stats_to_json(stats)
       stats.compact!
       say(Oj.dump(stats))
+    end
+
+    def default_block_param(row, key, default)
+      return default if row[key].nil?
+
+      row[key].strip
     end
   end
 end


### PR DESCRIPTION
#262 Add new tootctl command namely tootctl domains import_blocked

commands that can be performed
toolctl domains import_blocked
bin/tootctl domains import_blocked
toolctl domains import_blocked -u different-csv-url

This command can take in -u as the url option if any different url is required to be imported, else it will take the default url, i.e 
https://csv.rathersafe.space/f.php?d=1&h=39IM2DCd which is a list fetched from https://rathersafe.space/fediblock.

This will also add all the domains in a similar manner as the import feature performed for #261. This will also work for the format provided by the export feature.

Since test cases are non existing for these cli features. I have tested them manually and take some screen shot for reference.
![Screen Shot 2021-11-18 at 11 50 05 PM](https://user-images.githubusercontent.com/29198261/142473024-8e074230-5c39-49ad-a425-8174a10ba1cd.png)
![Screen Shot 2021-11-18 at 11 49 58 PM](https://user-images.githubusercontent.com/29198261/142473049-b09c09ee-a0f0-46f4-84e0-500c2472fbca.png)
![Screen Shot 2021-11-19 at 12 00 22 AM](https://user-images.githubusercontent.com/29198261/142473056-fba588f8-0075-4515-8fbd-f7dfa6d3a621.png)
![Screen Shot 2021-11-19 at 12 00 36 AM](https://user-images.githubusercontent.com/29198261/142473133-b233a4b9-fef2-410b-9a37-4469c6c7132d.png)

This reference below when all the blocklist are already present.
![Screen Shot 2021-11-19 at 12 15 43 AM](https://user-images.githubusercontent.com/29198261/142473200-559503f7-92a0-4c42-a199-7ef69e241864.png)
