### PR TITLE
Allow editing of favicon from the UI (manually rebuilt version)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,6 +70,9 @@ module ApplicationHelper
   end
 
   def favicon_path
+    site_upload = SiteUpload.find_by(var: 'favicon')
+    return site_upload.file.url unless site_upload.nil?
+
     env_suffix = Rails.env.production? ? '' : '-dev'
     "/favicon#{env_suffix}.ico"
   end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -28,6 +28,7 @@ class Form::AdminSettings
     thumbnail
     hero
     mascot
+    favicon
     trends
     trendable_by_default
     show_domain_blocks
@@ -55,6 +56,7 @@ class Form::AdminSettings
     thumbnail
     hero
     mascot
+    favicon
   ).freeze
 
   attr_accessor(*KEYS)

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -41,6 +41,9 @@
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :mascot, as: :file, wrapper: :with_block_label, label: t('admin.settings.mascot.title'), hint: site_upload_delete_hint(t('admin.settings.mascot.desc_html'), :mascot)
 
+    .fields-row__column.fields-row__column-6.fields-group
+      = f.input :favicon, as: :file, wrapper: :with_block_label, label: t('admin.settings.favicon.title'), hint: site_upload_delete_hint(t('admin.settings.favicon.desc_html'), :favicon)
+
   %hr.spacer/
 
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -664,6 +664,9 @@ en:
         users: To logged-in local users
       domain_blocks_rationale:
         title: Show rationale
+      favicon:
+        desc_html: Displayed on every page. At least 192×192px recommended. When not set, falls back to default favicon
+        title: Favicon image
       hero:
         desc_html: Displayed on the frontpage. At least 600x100px recommended. When not set, falls back to server thumbnail
         title: Hero image


### PR DESCRIPTION
Fixes #245 

This was created from #273 by manually re-applying each relevant changed line.