### PR TITLE
remove pry as a depedencies (#306)

### DIFF
--- a/gems/ecko-plugins/lib/ecko/plugins/stripe/rails/routes.rb
+++ b/gems/ecko-plugins/lib/ecko/plugins/stripe/rails/routes.rb
@@ -1,6 +1,5 @@
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/hash/slice"
-require 'pry'
 
 module ActionDispatch::Routing
   class Mapper


### PR DESCRIPTION
Removes pry dependencies which doesnt seem to be in the non development gems.
![Screen Shot 2021-12-10 at 1 15 53 AM](https://user-images.githubusercontent.com/29198261/145461056-27785ccf-c530-4e64-9acf-b9820e4ee2aa.png)
Docker compose build worked smoothly on my system.
