### PR TITLE
Fix not a string error by using the proper equals signs

### DIFF
--- a/docs/INSTALL_DOCKER_COMPOSE.md
+++ b/docs/INSTALL_DOCKER_COMPOSE.md
@@ -27,10 +27,10 @@ If you're not making any local code changes or customizations on your instance, 
 2. Add environment variables to the `db` section: 
     ```yaml
     environment:
-      - POSTGRES_PASSWORD: xyz <-- choose a safe one, 20-30 chars
-      - POSTGRES_DB: ecko_production
-      - POSTGRES_USER: ecko
-      - POSTGRES_HOST_AUTH_METHOD: trust
+      - POSTGRES_PASSWORD=xyz <-- choose a safe one, 20-30 chars
+      - POSTGRES_DB=ecko_production
+      - POSTGRES_USER=ecko
+      - POSTGRES_HOST_AUTH_METHOD=trust
     ``` 
 3. To use pre-built images comment out the `build: .` lines for the `web`, `streaming`, and `sidekiq` services.
 4. Save the file and exit the text editor.


### PR DESCRIPTION
While installing another docker-compose setup, ran across this error:

```
$ docker-compose run --rm web bundle exec rake mastodon:setup
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.db.environment contains {"POSTGRES_PASSWORD": "thesecretpassword"}, which is an invalid type, it should be a string
```

This turned out to be a typo where colons were used instead of equals for these config vars.