### PR TITLE
fix database pk error while creating package (#365)

### DIFF
--- a/lib/mastodon/donations_cli.rb
+++ b/lib/mastodon/donations_cli.rb
@@ -69,6 +69,7 @@ module Mastodon
         -r, --reference     silver_tier, gold_tier or platinum_tier for badge color
     LONG_DESC
     def create_package(title, amount, description)
+      ActiveRecord::Base.connection.reset_pk_sequence!('donation_packages')
       DonationPackage.create(
         amount: amount,
         currency: options[:currency],


### PR DESCRIPTION
Fixes #365 
The pk sequence is not indexed correctly. We need to reset it to run it correctly.