### PR TITLE
Issue/373

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -101,7 +101,7 @@ class Account < ApplicationRecord
   validates_with UnreservedUsernameValidator, if: -> { local? && will_save_change_to_username? }
   validates_with UnreservedUsernameValidator, if: -> { local? && will_save_change_to_username? }
   validates :display_name, length: { maximum: 30 }, if: -> { local? && will_save_change_to_display_name? }
-  validates :note, note_length: { maximum: 500 }, length: { minimum: lambda { |_obj| StaticSetting.registry.min_profile_description_character } }, if: -> { local? && will_save_change_to_note? }
+  validates :note, note_length: { maximum: 500 }, length: { minimum: lambda { |_obj| StaticSetting.registry.min_profile_description_character.to_i } }, if: -> { local? && will_save_change_to_note? }
   validates :fields, length: { maximum: 4 }, if: -> { local? && will_save_change_to_fields? }
 
   scope :remote, -> { where.not(domain: nil) }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -335,7 +335,7 @@ class Account < ApplicationRecord
   end
 
   def build_fields
-    field_size = StaticSetting.registry.user_fields
+    field_size = StaticSetting.registry.user_fields || StaticSetting::DEFAULT_USER_FIELDS
 
     return if fields.size >= field_size
 

--- a/app/models/static_setting.rb
+++ b/app/models/static_setting.rb
@@ -12,6 +12,8 @@
 #  updated_at                        :datetime         not null
 #
 class StaticSetting < ApplicationRecord
+	DEFAULT_USER_FIELDS = 4
+
 	validates :max_post_character, numericality: { greater_than: 0, less_than_or_equal_to: 5000}, unless: -> { max_post_character.blank? }
 	validates :max_poll_options, numericality: { greater_than: 0, less_than_or_equal_to: 10}, unless: -> { max_poll_options.blank? }
 	validates :max_poll_option_character, numericality: { greater_than: 0, less_than_or_equal_to: 1000}, unless: -> { max_poll_option_character.blank? }
@@ -27,7 +29,7 @@ class StaticSetting < ApplicationRecord
 			max_post_character: ENV['MAX_TOOT_CHARS'] || 500,
 			max_poll_options: ENV['MAX_POLL_OPTIONS'] || 4,
 			max_poll_option_character: ENV['MAX_POLL_OPTION_CHARS'] || 50,
-			user_fields: 4,
+			user_fields: DEFAULT_USER_FIELDS,
 			min_profile_description_character: 0
 		}
 	end


### PR DESCRIPTION
Helps with #373 
This is something that i found.
1. When the values of StaticSetting.registry.user_fields is null then the profile settings page fail to load. This actually can happen if the registry that is the last static settings is updated manually from the console. The interesting thing is, the registry creates based on the the default values. Currently the issue should be fixed but need to what might be the case when ewe face a different problem next time.
2. When the registry value min_profile_description_character is null, than the profile save gives 500. This also is fixed by setting the validation to integer which means that even if the value is nil, .to_i will change it to 0 which is the defatult value. 