### PR TITLE
revert poll option change (#377)

### DIFF
--- a/app/serializers/rest/poll_serializer.rb
+++ b/app/serializers/rest/poll_serializer.rb
@@ -4,10 +4,7 @@ class REST::PollSerializer < ActiveModel::Serializer
   attributes :id, :expires_at, :expired,
              :multiple, :votes_count, :voters_count
 
-  has_many :loaded_options, key: :options do
-    object.loaded_options.shuffle
-  end
-
+  has_many :loaded_options, key: :options
   has_many :emojis, serializer: REST::CustomEmojiSerializer
 
   attribute :voted, if: :current_user?


### PR DESCRIPTION
Revert as said in #377.
We might need to reopen #199 as well. We can fix this by applying the option id as the voted value rather than the option index. @weex if you feel its relevant than please reopen #199, I will fix that.
