### PR TITLE
Use unsafe-wasm-eval in script-src CSP per Mastodon v4.0.2

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -36,7 +36,7 @@ Rails.application.config.content_security_policy do |p|
     p.worker_src  :self, :blob, assets_host
   else
     p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url
-    p.script_src  :self, assets_host
+    p.script_src  :self, assets_host, "'wasm-unsafe-eval'"
     p.child_src   :self, :blob, assets_host
     p.worker_src  :self, :blob, assets_host
   end


### PR DESCRIPTION
Another security fix included in Mastodon's bump to 4.0.2

Commit and discussion: https://github.com/mastodon/mastodon/commit/b46b7c3d5e4e932d61d74418957c824ce7c5f9f7