### PR TITLE
Stop text on long toots from overflowing

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1008,7 +1008,7 @@
   line-height: 20px;
   word-wrap: break-word;
   font-weight: 400;
-  overflow: visible;
+  overflow: hidden;
   padding-top: 5px;
   clear: both;
 


### PR DESCRIPTION
Related: #447

Tested on local with `@corvina@qoto.org` profile.

<img width="606" alt="Screen Shot 2022-11-29 at 9 17 26 PM" src="https://user-images.githubusercontent.com/38776/204713629-fb4dd745-eca9-4311-8854-959c236b2385.png">
