### PR TITLE
Bump devise-two-factor from 4.0.1 to 4.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'iso-639'
 gem 'chewy', '~> 5.2'
 gem 'cld3', '~> 3.4.2'
 gem 'devise', '~> 4.8'
-gem 'devise-two-factor', '~> 4.0'
+gem 'devise-two-factor', '~> 4.0.2'
 
 group :pam_authentication, optional: true do
   gem 'devise_pam_authenticatable2', '~> 9.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,11 +175,11 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-two-factor (4.0.1)
-      activesupport (< 6.2)
+    devise-two-factor (4.0.2)
+      activesupport (< 7.1)
       attr_encrypted (>= 1.3, < 4, != 2)
       devise (~> 4.0)
-      railties (< 6.2)
+      railties (< 7.1)
       rotp (~> 6.0)
     devise_pam_authenticatable2 (9.2.0)
       devise (>= 4.0.0)
@@ -530,7 +530,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
-    rotp (6.2.0)
+    rotp (6.2.2)
     rpam2 (4.0.2)
     rqrcode (2.1.0)
       chunky_png (~> 1.0)
@@ -745,7 +745,7 @@ DEPENDENCIES
   concurrent-ruby
   connection_pool
   devise (~> 4.8)
-  devise-two-factor (~> 4.0)
+  devise-two-factor (~> 4.0.2)
   devise_pam_authenticatable2 (~> 9.2)
   discard (~> 1.2)
   doorkeeper (~> 5.5)
@@ -847,3 +847,9 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush (~> 0.3)
   xorcist (~> 1.1)
+
+RUBY VERSION
+   ruby 2.7.4p191
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
Creating this manually to see if there's any difference as to CI passing.